### PR TITLE
Hotfix/v1.0.1 -> main

### DIFF
--- a/workflows/dxnextflowrna.nf
+++ b/workflows/dxnextflowrna.nf
@@ -32,11 +32,14 @@ workflow DXNEXTFLOWRNA {
         .combine(Channel.fromPath(params.fai))
         .map { fasta, fai -> [[id: fasta.getSimpleName()], fasta, fai] }
         .collect()
-    ch_gene_bed = Channel.fromPath(params.gene_bed)
+    ch_gene_bed = Channel
+        .fromPath(params.gene_bed)
+        .collect()
     ch_gtf = Channel
         .fromPath(params.gtf)
         .map(createMetaWithIdSimpleName)
         .first()
+        .collect()
     ch_star_index = Channel
         .fromPath(params.star_index)
         .map(createMetaWithIdSimpleName)


### PR DESCRIPTION
This PR fixes an issue where output files from rseqc modules (outputs in the folder described here (https://github.com/UMCUGenetics/DxNextflowRNA/blob/main/conf/modules.config#L93) were only available for 1 of the samples.

In some of these rseqc processes, `ch_gene_bed`  is used as input together with the sample bam (e.g., see: https://github.com/UMCUGenetics/DxNextflowRNA/blob/main/modules/nf-core/rseqc/junctionannotation/main.nf). Since `ch_gene_bed` was originally declared as  `ch_gene_bed = Channel.fromPath(params.gene_bed)`, nextflow considers this a 'queue channel'. In other words, the `ch_gene_bed` channel is used for the first sample and when the second sample comes around `ch_gene_bed` is empty.

The fix is rather simple, cast the channel to a 'value channel' which is not consumed upon usage. 

`ch_gtf` is currently used only once and therefore not causing problems, but might give issues in the future. So I corrected it preemptively. 

