### PR TITLE
hotfix: change dx_tracks path from develop to production

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -25,7 +25,7 @@ params {
     star_index               = "${params.genome_base}/ref_genome.fa.star.idx/"
 
     // Dx_tracks references
-    dx_tracks_path               = '/hpc/diaggen/software/development/Dx_tracks/'
+    dx_tracks_path               = '/hpc/diaggen/software/production/Dx_tracks/'
 
     // Custom reference files GRCh38
     gene_bed                     = "${params.dx_tracks_path}/rna/${params.gencode_version_name}.ref_annot.gtf.bed"


### PR DESCRIPTION
The pipeline now refers to Dx_Tracks files from the production folder, rather than the develop folder.

The files in Dx_tracks that were being used in this workflow are identical between the production folder and develop folder.