### PR TITLE
correct featureCounts publish format

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -245,7 +245,7 @@ process {
                 path: "${params.outdir}/feature_counts/",
                 mode: params.publish_dir_mode,
                 saveAs: { filename ->
-                filename.replace(".featureCounts", "").replace("cntrl", "cntrl.cntrl").replace("plusCHX", "plusCHX.chx")
+                    filename.replace(".featureCounts", "").replaceAll(/(?i)(cntrl|control|ctrl)/, "cntrl.cntrl").replace("plusCHX", "plusCHX.chx")
                 }
             ]
         ]
@@ -271,7 +271,7 @@ process {
                 path: "${params.outdir}/feature_counts/",
                 mode: params.publish_dir_mode,
                 saveAs: { filename ->
-                filename.replace(".featureCounts", "").replace("cntrl", "cntrl.cntrl").replace("plusCHX", "plusCHX.chx")
+                filename.replace(".featureCounts", "").replaceAll(/(?i)(cntrl|control|ctrl)/, "cntrl.cntrl").replace("plusCHX", "plusCHX.chx")
                 }
             ]
         ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -271,7 +271,7 @@ process {
                 path: "${params.outdir}/feature_counts/",
                 mode: params.publish_dir_mode,
                 saveAs: { filename ->
-                filename.replace(".featureCounts", "").replaceAll(/(?i)(cntrl|control|ctrl)/, "cntrl.cntrl").replace("plusCHX", "plusCHX.chx")
+                    filename.replace(".featureCounts", "").replaceAll(/(?i)(cntrl|control|ctrl)/, "cntrl.cntrl").replace("plusCHX", "plusCHX.chx")
                 }
             ]
         ]


### PR DESCRIPTION
Rename featurecounts control samples to the correct output format, with more robust pattern matching