### PR TITLE
increases resources main job and tmpspace umitools dedup

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -295,7 +295,8 @@ process {
     }
 
     withName: UMITOOLS_DEDUP {
-        clusterOptions = "${params.cluster_options} --gres=tmpspace:40G"
+        cache          = false // Never resume this process to avoid downstream errors
+        clusterOptions = "${params.cluster_options} --gres=tmpspace:200G"
         ext.args       = {
             [
                 "--umi-separator=:",

--- a/run_nextflow_rna.sh
+++ b/run_nextflow_rna.sh
@@ -50,7 +50,7 @@ fi
 
 sbatch <<EOT
 #!/bin/bash
-#SBATCH --time=24:00:00
+#SBATCH --time=48:00:00
 #SBATCH --nodes=1
 #SBATCH --mem 10G
 #SBATCH --gres=tmpspace:10G


### PR DESCRIPTION
Increasing the tmpspace for umitools dedup fixes an issue where pysam (internally used by umitools) runs out of tmpspace. Interestingly enough, this error is captured by slurm, but not by nextflow. Consequently nextflow attempts to continue the pipeline, but the process following UMITOOLS_DEDUP (SAMTOOLS_INDEX) fails because the bam file is empty.